### PR TITLE
add authMiddleware file to protect a route

### DIFF
--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,0 +1,32 @@
+const jwt = require('jsonwebtoken');
+const asyncHandler = require('express-async-handler');
+const User = require('../models/userModel');
+
+const protect = asyncHandler( async (req, res, next) => {
+    let token;
+
+    if(req.headers.authorization && req.headers.authorization.startsWith('Bearer')) {        
+        try {
+            // Get token from header
+            token = req.headers.authorization.split(' ')[1];
+            // Verify token
+            const decoded = jwt.verify(token, process.env.JWT_SECRET);
+            // Get user from token
+            req.id = await User.findById(decoded.id).select('-password');
+
+            next();
+        }         
+        catch (error) {
+            console.log("error");
+            res.status(401);
+            throw new error("Not authorized")
+        }        
+    }  
+    
+    if(!token) {
+        res.status(401);
+        throw new error("Not authorized")
+    }
+});
+
+module.exports = { protect };


### PR DESCRIPTION
In the `backend/middleware.js` folder, a file is created named `authMiddleware.js`. At the top, the `jsonwebtoken` is brought in as `jwt`, the `express-async-handler` is brought in as `asyncHandler`, and the `models/userModel` is brought in as `User`.

A `protect` function is created that uses `asyncHandler` with `async` and three parameters of `req`, `res`, and `next`. Inside the function, a variable is declared named `token`. Then an `if` statement is created to check if `req.headers.authorization` exists, and if `req.headers.authorization.startsWith('Bearer')`. Inside this conditional, a `try` `catch` block is added. Inside the `try`, the `token` variable is set to `req.headers.authorization.split(' ')[1]`, to split into an array to access the token. Then the token is verified by creating a variable named `decoded`, which is set to equal `jwt.verify` which is passed in `token` and the environment variable `JWT_SECRET`. To get the user from the token, the `req.user` is set to equal `User.findById(decoded.id).select('-password')`, which uses the user model to find the id inside the token, but exludes the password. This is all preceded by `await`. Then `next()` is called, to call the next piece of middleware. In the `catch` block, a parameter of `error` is added. A `console.log` is added with the `error`. A `res.status` is set to 401. And a `new errror` is thrown to say "Not authorized". 

Outside of the `if` statement, another `if` statement is added that checks if there is not a `token`. If not, a `res.status` is set to 401. And a `new errror` is thrown to say "Not authorized". At the bottom, an `export` is set for the `protect` function.